### PR TITLE
Add stdin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ cfg.toXML();    // output as a XML string.
 or from a command line:
 ```
 to-json.js input.xml
-to-yaml input.json
-to-xml ipnut.yml
+to-yaml.js input.json
+to-xml.js ipnut.yml
+```
+or via STDIN
+```
+to-json.js < input.xml
+to-yaml.js < input.json
+to-xml.js < ipnut.yml
 ```

--- a/bin/to-json.js
+++ b/bin/to-json.js
@@ -4,6 +4,16 @@ const Path = require('path');
 const Configuration = require(Path.join(__dirname, '..', 'configuration.js'));
 
 let input = process.argv[2];
-let cfg = Configuration.fromFile(input);
+let cfg;
+
+if (input) {
+  // a filename argument was given.
+  cfg = Configuration.fromFile(input);
+
+} else {
+  // no arguments given so read STDIN.
+  cfg = Configuration.fromSTDIN();
+
+}
 
 process.stdout.write(cfg.toJSON());

--- a/bin/to-xml.js
+++ b/bin/to-xml.js
@@ -4,6 +4,16 @@ const Path = require('path');
 const Configuration = require(Path.join(__dirname, '..', 'configuration.js'));
 
 let input = process.argv[2];
-let cfg = Configuration.fromFile(input);
+let cfg;
+
+if (input) {
+  // a filename argument was given.
+  cfg = Configuration.fromFile(input);
+
+} else {
+  // no arguments given so read STDIN.
+  cfg = Configuration.fromSTDIN();
+
+}
 
 process.stdout.write(cfg.toXML());

--- a/bin/to-yaml.js
+++ b/bin/to-yaml.js
@@ -4,6 +4,16 @@ const Path = require('path');
 const Configuration = require(Path.join(__dirname, '..', 'configuration.js'));
 
 let input = process.argv[2];
-let cfg = Configuration.fromFile(input);
+let cfg;
+
+if (input) {
+  // a filename argument was given.
+  cfg = Configuration.fromFile(input);
+
+} else {
+  // no arguments given so read STDIN.
+  cfg = Configuration.fromSTDIN();
+
+}
 
 process.stdout.write(cfg.toYAML());

--- a/configuration.js
+++ b/configuration.js
@@ -51,7 +51,7 @@ class Configuration extends Object {
   }
 
   static fromSTDIN() {
-    let raw = STDIN.get();
+    let raw = this.STDIN.get();
     let type;
 
     if (Parsers.isJSON(raw)) {
@@ -63,6 +63,11 @@ class Configuration extends Object {
     }
 
     return new this(raw, type);
+  }
+
+  static get STDIN() {
+    // exposed for testability/stubbing.
+    return STDIN;
   }
 
 }

--- a/configuration.js
+++ b/configuration.js
@@ -13,10 +13,15 @@ const STDIN = require(Path.join(libPath, 'stdin.js'));
 
 class Configuration extends Object {
 
-  constructor(input) {
+  constructor(raw, type) {
     super();
 
-    Object.assign(this, input);
+    let parser = Parsers[type];
+    let inpStr = raw.toString();
+
+    let content = parser.parse(inpStr);
+
+    Object.assign(this, content);
   }
 
   toJSON() {

--- a/configuration.js
+++ b/configuration.js
@@ -47,10 +47,22 @@ class Configuration extends Object {
     let type = MIME.lookup(filename);
     let raw = File.readFileSync(filename);
 
-    let parser = Parsers[type];
-    let content = parser.parse(raw.toString());
+    return new this(raw, type);
+  }
 
-    return new this(content);
+  static fromSTDIN() {
+    let raw = STDIN.get();
+    let type;
+
+    if (Parsers.isJSON(raw)) {
+      type = MIME.lookup('json');
+    } else if (Parsers.isYAML(raw)) {
+      type = MIME.lookup('yml');
+    } else if (Parsers.isXML(raw)) {
+      type = MIME.lookup('xml');
+    }
+
+    return new this(raw, type);
   }
 
 }

--- a/configuration.js
+++ b/configuration.js
@@ -8,6 +8,7 @@ const XML = require('fast-xml-parser');
 
 const libPath = Path.join(__dirname, 'lib');
 const Parsers = require(Path.join(libPath, 'parsers.js'));
+const STDIN = require(Path.join(libPath, 'stdin.js'));
 
 
 class Configuration extends Object {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -6,6 +6,25 @@ const Parsers = {
   'text/yaml': YAML,
   'application/json': JSON,
   'application/xml': XML,
+
+  isJSON: function(str) {
+    let match = str.match(/^\{[\{\}\[\]\"\'\w\s\:\,]+[\}\s]$/gi);
+
+    return !!match && match.toString() === str;
+  },
+
+  isYAML: function(str) {
+    let match = str.match(/[\w\s\:\[\]^\{^\}^\<^\>\,\-]+/gi);
+
+    return !!match && match.toString() === str;
+  },
+
+  isXML: function(str) {
+    let match = str.match(/^[\<\>\w\s\/\=\'\"]+$/gi);
+
+    return !!match && match.toString() === str;
+  },
+
 };
 
 

--- a/lib/stdin.js
+++ b/lib/stdin.js
@@ -1,0 +1,61 @@
+
+const File = require('fs');
+
+
+// adapted from an implementation by Thaddée Tyl (https://espadrine.github.io/).
+// original source avaiable at https://gist.github.com/espadrine/172658142820a356e1e0
+
+const stdin = '';
+
+
+class STDIN {
+
+  static get BUFSIZE() {
+    return this._bufSize || 256;
+  }
+
+  static set BUFSIZE(val) {
+    return this._bufSize = val;
+  }
+
+  static get() {
+    let fd;
+    let contents = '';
+    let buf = new Buffer(this.BUFSIZE);
+
+    try {
+      // we'll try to use /dev/stdin in *nix environments..
+      fd = File.openSync('/dev/stdin', 'rs');
+    } catch(error) {
+      // ..and fallback to Node's process.stdin otherwise.
+      fd = process.stdin.fd;
+    }
+
+    while (true) {
+
+      try {
+        buf = File.readSync(fd, buf, 0, this.BUFSIZE, null);
+        contents += buf.toString();
+
+      } catch(err) {
+
+        if (err.code === 'EOF') {
+          break;
+        } else {
+          throw err;
+        }
+
+      }
+
+    }
+
+    if (fd !== process.stdin) {
+      console.log('closing device');
+      fs.closeSync(fd);
+    } else {
+    }
+
+    return contents;
+  }
+
+}

--- a/lib/stdin.js
+++ b/lib/stdin.js
@@ -2,12 +2,6 @@
 const File = require('fs');
 
 
-// adapted from an implementation by Thaddée Tyl (https://espadrine.github.io/).
-// original source avaiable at https://gist.github.com/espadrine/172658142820a356e1e0
-
-const stdin = '';
-
-
 class STDIN {
 
   static get BUFSIZE() {
@@ -19,43 +13,25 @@ class STDIN {
   }
 
   static get() {
-    let fd;
+    let len = 0;
     let contents = '';
-    let buf = new Buffer(this.BUFSIZE);
+    let file = process.stdin.fd;
 
-    try {
-      // we'll try to use /dev/stdin in *nix environments..
-      fd = File.openSync('/dev/stdin', 'rs');
-    } catch(error) {
-      // ..and fallback to Node's process.stdin otherwise.
-      fd = process.stdin.fd;
-    }
+    let bufSize = this.BUFSIZE;
+    let buf = new Buffer(bufSize);
 
-    while (true) {
+    do {
+      len = File.readSync(file, buf, 0, bufSize, null);
 
-      try {
-        buf = File.readSync(fd, buf, 0, this.BUFSIZE, null);
-        contents += buf.toString();
+      let str = buf.toString();
+      contents += str.slice(0, len);
 
-      } catch(err) {
-
-        if (err.code === 'EOF') {
-          break;
-        } else {
-          throw err;
-        }
-
-      }
-
-    }
-
-    if (fd !== process.stdin) {
-      console.log('closing device');
-      fs.closeSync(fd);
-    } else {
-    }
+    } while (len > 0);
 
     return contents;
   }
 
 }
+
+
+module.exports = STDIN;

--- a/spec/configuration_spec.js
+++ b/spec/configuration_spec.js
@@ -24,7 +24,7 @@ describe(Configuration.name, () => {
       instance = Configuration.fromFile(jsonStub);
     });
 
-    describe('the toJSON() function.', () => {
+    describe('the toJSON() function', () => {
       beforeEach(() => {
         result = instance.toJSON();
       });
@@ -41,7 +41,7 @@ describe(Configuration.name, () => {
 
     });
 
-    describe('the toXML() function.', () => {
+    describe('the toXML() function', () => {
       beforeEach(() => {
         result = instance.toXML();
       });
@@ -58,7 +58,7 @@ describe(Configuration.name, () => {
 
     });
 
-    describe('the toYAML() function.', () => {
+    describe('the toYAML() function', () => {
       beforeEach(() => {
         result = instance.toYAML();
       });

--- a/spec/configuration_spec.js
+++ b/spec/configuration_spec.js
@@ -1,7 +1,11 @@
 
 const Path = require('path');
+const File = require('fs');
+
 const YAML = require('yaml');
 const XML = require('fast-xml-parser');
+
+const MIME = require('mime-types');
 
 const specPath = Path.join(__dirname);
 const rootPath = Path.join(specPath, '..');
@@ -151,6 +155,104 @@ describe(Configuration.name, () => {
         expect(ary[1]).toEqual(2);
         expect(ary[2]).toEqual(3);
         expect(ary[3]).toEqual(4);
+      });
+
+    });
+
+  });
+
+  describe('the fromSTDIN() static function', () => {
+    let input;
+    let stub;
+    let promise = Promise.resolve();
+    let file;
+
+    beforeEach(() => {
+      let baseLib = Configuration.STDIN;
+
+      input = File.readFileSync(stub);
+
+      spyOn(baseLib, 'get')
+        .and.returnValue(input.toString(), MIME.lookup(stub));
+    });
+
+    describe('given JSON input', () => {
+      stub = jsonStub;
+
+      it('parses the given input object', () => {
+        let res = Configuration.fromSTDIN();
+        let obj = res.anObject;
+
+        expect(obj.one).toEqual(1);
+        expect(obj.two).toEqual(2);
+        expect(obj.three).toEqual(3);
+        expect(obj.four).toEqual(4);
+
+      });
+
+      it('parses the given input array', () => {
+        let res = Configuration.fromSTDIN();
+        let ary = res.anArray;
+
+        expect(ary[0]).toEqual(1);
+        expect(ary[1]).toEqual(2);
+        expect(ary[2]).toEqual(3);
+        expect(ary[3]).toEqual(4);
+
+      });
+
+    });
+
+    describe('given YAML input', () => {
+      stub = yamlStub;
+
+      it('parses the given input object', () => {
+        let res = Configuration.fromSTDIN();
+        let obj = res.anObject;
+
+        expect(obj.one).toEqual(1);
+        expect(obj.two).toEqual(2);
+        expect(obj.three).toEqual(3);
+        expect(obj.four).toEqual(4);
+
+      });
+
+      it('parses the given input array', () => {
+        let res = Configuration.fromSTDIN();
+        let ary = res.anArray;
+
+        expect(ary[0]).toEqual(1);
+        expect(ary[1]).toEqual(2);
+        expect(ary[2]).toEqual(3);
+        expect(ary[3]).toEqual(4);
+
+      });
+
+    });
+
+    describe('given XML input', () => {
+      stub = xmlStub;
+
+      it('parses the given input object', () => {
+        let res = Configuration.fromSTDIN();
+        let obj = res.anObject;
+
+        expect(obj.one).toEqual(1);
+        expect(obj.two).toEqual(2);
+        expect(obj.three).toEqual(3);
+        expect(obj.four).toEqual(4);
+
+      });
+
+      it('parses the given input array', () => {
+        let res = Configuration.fromSTDIN();
+        let ary = res.anArray;
+
+        expect(ary[0]).toEqual(1);
+        expect(ary[1]).toEqual(2);
+        expect(ary[2]).toEqual(3);
+        expect(ary[3]).toEqual(4);
+
       });
 
     });

--- a/spec/lib/parsers_spec.js
+++ b/spec/lib/parsers_spec.js
@@ -1,0 +1,89 @@
+
+const Path = require('path');
+const File = require('fs');
+
+const specPath = Path.join(__dirname, '..');
+const rootPath = Path.join(specPath, '..');
+const supportPath = Path.join(specPath, 'support');
+
+const xmlStub = Path.join(supportPath, 'input.xml');
+const yamlStub = Path.join(supportPath, 'input.yml');
+const jsonStub = Path.join(supportPath, 'input.json');
+
+const Parsers = require(Path.join(rootPath, 'lib', 'parsers.js'));
+
+
+describe(Parsers.name, () => {
+  let content = {
+    json: File.readFileSync(jsonStub).toString(),
+    yaml: File.readFileSync(yamlStub).toString(),
+    xml: File.readFileSync(xmlStub).toString(),
+  };
+
+  describe('the isJSON() static function', () => {
+
+    it('returns true given valid JSON data', () => {
+      let result = Parsers.isJSON(content.json);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false given valid YAML data', () => {
+      let result = Parsers.isJSON(content.yaml);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false given valid XML data', () => {
+      let result = Parsers.isJSON(content.xml);
+
+      expect(result).toBe(false);
+    });
+
+  });
+
+  describe('the isYAML() static function', () => {
+
+    it('returns false given valid JSON data', () => {
+      let result = Parsers.isYAML(content.json);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true given valid YAML data', () => {
+      let result = Parsers.isYAML(content.yaml);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false given valid XML data', () => {
+      let result = Parsers.isYAML(content.xml);
+
+      expect(result).toBe(false);
+    });
+
+  });
+
+  describe('the isXML() static function', () => {
+
+    it('returns false given valid JSON data', () => {
+      let result = Parsers.isXML(content.json);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false given valid YAML data', () => {
+      let result = Parsers.isXML(content.yaml);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true given valid XML data', () => {
+      let result = Parsers.isXML(content.xml);
+
+      expect(result).toBe(true);
+    });
+
+  });
+
+});


### PR DESCRIPTION
* added ```getSTDIN()``` mathod to exported object.
* added Standard Input support to scripts: `/bin/to-xml.js`, `/bin/to-yml.js`, and `/bin/to-json.js`.
* minor cleanup and refactoring of internal functionality and tests:
  * updated exported instance to use new input arguments: a raw input string and mime type.